### PR TITLE
docs(governance): sync stale 3-pillars content to current governance (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ before acting and pushes after each change.
   it is NEVER moved to archived. Giving up on a failed TRDD = cancel → archived.
 ```
 
-Full rules: `~/.claude/rules/trdd-approval-tiers.md`. Decide proposals fast with
-the core `ama-proposal-approvals` skill (`approved: 4,6` / `refused: 7,8`).
+Full rules: the IND base `~/.claude/rules/trdd-design-tasks.md` (folder lifecycle) +
+the ai-maestro overlay `aimaestro-trdd-approval.md` (tier ladder + batch-approval syntax).
+Decide proposals fast with the core `amama-proposal-approvals` skill
+(`approved: 4,6` / `refused: 7,8`).
 
 ## Plugin Components
 

--- a/agents/ai-maestro-assistant-manager-agent-main-agent.md
+++ b/agents/ai-maestro-assistant-manager-agent-main-agent.md
@@ -22,7 +22,7 @@ skills:
   - ama-prrd-edit
   - ama-prrd-propose
   - ama-kanban-render
-  - ama-proposal-approvals
+  - amama-proposal-approvals
   - ai-maestro-agents-management
 ---
 
@@ -139,8 +139,8 @@ AI Maestro defines these governance titles (plus the HUMAN node; USERS — nativ
 | `ARCHITECT` | Design lead — architecture decisions, requirements analysis, design documents. |
 | `INTEGRATOR` | Integration specialist — code review, quality gates, merge management. |
 | `MEMBER` | Team member. Works under COS/ORCHESTRATOR coordination. |
-| `MAINTAINER` | Governance-layer title — host-level maintenance and oversight. Reaches only MANAGER + HUMAN. |
-| `AUTONOMOUS` | Independent agent — operates outside team structure. Reaches MANAGER + peer AUTONOMOUS + HUMAN only (no COS per R6 v2). |
+| `MAINTAINER` | Governance-layer title — host-level maintenance and oversight. Reaches only MANAGER + HUMAN. Mandatory role plugin: `ai-maestro-maintainer-agent` (R9.13). |
+| `AUTONOMOUS` | Independent agent — operates outside team structure. Reaches MANAGER + peer AUTONOMOUS + HUMAN only (no COS per R6 v3). Mandatory role plugin: `ai-maestro-autonomous-agent` (R9.13). |
 | `ASSISTANT` | A non-MAESTRO user's auto-assigned agent (role plugin `ai-maestro-assistant-role-agent`, R38/R39). No team; obeys only its user + the MAESTRO; messages only those two; invisible to other agents. You do not manage it beyond ordinary MANAGER authority. |
 
 ### Manager Authority (C1)
@@ -220,7 +220,7 @@ A GovernanceRequest requires **dual-manager approval** (both local and remote ma
 
 Distinct from **GovernanceRequest Approval (C4)** above — two different approval axes:
 - **GovernanceRequest (C4)** = cross-host / agent-lifecycle ops (team & agent create / delete / wake / hibernate, title changes) — dual-manager approval via `$AID_AUTH`.
-- **Approval Tiers (here)** = *task* authorization — whether a TRDD may move from `proposal` to `planned` and be executed. Governed by `~/.claude/rules/trdd-approval-tiers.md`.
+- **Approval Tiers (here)** = *task* authorization — whether a TRDD may move from `proposal` to `planned` and be executed. Governed by the IND base `~/.claude/rules/trdd-design-tasks.md` (TRDD format + folder lifecycle) and the ai-maestro overlay `aimaestro-trdd-approval.md` (the tier ladder + transition authority). The old global `trdd-approval-tiers.md` / `manager-approval-defaults.md` are superseded by these IND/DEP names.
 
 Every AI Maestro agent operates on the single escalation ladder **Tier 0 → CHIEF-OF-STAFF → MANAGER → USER**. Your place in it:
 
@@ -229,9 +229,11 @@ Every AI Maestro agent operates on the single escalation ladder **Tier 0 → CHI
 - **Escalate Tier-3 to the USER** — GOLDEN-PRRD changes, rule promote / demote, and irreversible / owner-identity / shared-credential actions — then relay the USER's decision back down the chain.
 - **Author your own Tier-0** derived / coordination tasks directly in `design/tasks/` as `column: planned` — no approval needed for work inside your own mandate.
 
-**Deciding proposals fast.** Use the core **`ama-proposal-approvals`** skill to list `design/proposals/` numbered and act in one line: `approved: 4,6,22` (approve those; rest stay pending), `refused: 7,8` (refuse those; approve the rest by complement). Refused proposals (never approved) → `design/refused/`; once-approved tasks that finish/cancel/supersede → `design/archived/`. Full procedures: `trdd-approval-tiers.md` Part A.
+**Deciding proposals fast.** Use the core **`amama-proposal-approvals`** skill to list `design/proposals/` numbered and act in one line: `approved: 4,6,22` (approve those; rest stay pending), `refused: 7,8` (refuse those; approve the rest by complement). Refused proposals (never approved) → `design/refused/`; once-approved tasks that finish/cancel/supersede → `design/archived/`. Full procedures: `aimaestro-trdd-approval.md` Part A + the IND base `trdd-design-tasks.md` folder-lifecycle section. Before a code-bearing TRDD may reach `complete` or be archived as `completed`, confirm its `implementation-commits:` records the landed SHAs — that backtracking field is how a later bug is traced to the TRDD that introduced it (IND `trdd-design-tasks.md`); a docs/decision-only TRDD legitimately has none.
 
-**Baseline rulesets:** every repo carries the ratified `baseline-history-protect` + `baseline-pr-and-checks` pair; the **ai-maestro-janitor auto-enforces** it, and applying it **as-is is Tier 0** (no approval). You are the gate for **deviations** — never let an agent weaken, extend, or diverge from the baseline without your Tier-2 sign-off (forwarding GOLDEN / identity-touching cases to USER). See `manager-approval-defaults.md` §F for the EXEMPT (apply-as-is) vs NON-EXEMPT (deviation) split.
+**Baseline rulesets:** every repo carries the ratified `baseline-history-protect` + `baseline-pr-and-checks` pair; the **ai-maestro-janitor auto-enforces** it, and applying it **as-is is Tier 0** (no approval). You are the gate for **deviations** — never let an agent weaken, extend, or diverge from the baseline without your Tier-2 sign-off (forwarding GOLDEN / identity-touching cases to USER). See `aimaestro-manager-approval-defaults.md` §F for the EXEMPT (apply-as-is) vs NON-EXEMPT (deviation) split.
+
+**Governance overlays.** The ai-maestro DEP overlays that expand the IND base bind you: `aimaestro-trdd-approval.md` (tiers + transition authority), `aimaestro-manager-approval-defaults.md` (EXEMPT vs NON-EXEMPT), `aimaestro-prrd-governance.md` (PRRD per-title authority — you may add/revise SILVER rules; GOLDEN rules stay USER-only), and `aimaestro-kanban-multiagent.md` (the shared per-project board is the TRDD corpus; the GitHub Project + dashboard are one-way mirrors of it).
 
 ### TRDD lifecycle — at a glance
 

--- a/docs/AGENT_OPERATIONS.md
+++ b/docs/AGENT_OPERATIONS.md
@@ -72,15 +72,18 @@ MAESTRO user <-> MANAGER <-> COS <-> Members
 
 ## Task Status Reference
 
-AI Maestro uses 5 task statuses:
+AI Maestro uses the **ratified 17-column kanban vocabulary**, 1:1 with the TRDD `column:`
+field (14 lifecycle + 3 exception). Consumers align TO it, never the reverse (ai-maestro
+R25 / TRDD-YUGDER9D). GitHub `status:*` labels carry the column name verbatim:
 
-| Status | Code | Label |
-|--------|------|-------|
-| Backlog | `backlog` | `status:backlog` |
-| Pending | `pending` | `status:pending` |
-| In Progress | `in_progress` | `status:in-progress` |
-| Review | `review` | `status:review` |
-| Completed | `completed` | `status:completed` |
+```
+backburner → todo → design → dispatch → dev → testing → ai_review → human_review → complete
+  → publish → published   (tools)  |  → deploy → live → live_auditing   (services)
+exception (orthogonal): blocked · failed · superseded
+```
+
+Full column table + GitHub-Project mapping:
+`skills/amama-github-routing/references/task-system-sync.md`.
 
 ## Agent Creation (R29/R30)
 

--- a/docs/FULL_PROJECT_WORKFLOW.md
+++ b/docs/FULL_PROJECT_WORKFLOW.md
@@ -43,7 +43,7 @@ resolve AID auth internally; AMAMA supplies no governance/sudo password (R28/R32
 | Step | Actor | Action |
 |------|-------|--------|
 | 15 | Members | Work on assigned tasks |
-| 16 | COS | Move tasks: `pending` -> `in_progress` |
+| 16 | COS | Move tasks: `dispatch` -> `dev` |
 | 17 | Members | Complete work, notify COS |
 | 18 | COS | Approve PR creation |
 | 19 | Members | Create PRs |
@@ -54,14 +54,14 @@ resolve AID auth internally; AMAMA supplies no governance/sudo password (R28/R32
 |------|-------|--------|
 | 20 | COS | Request review from integrator-skilled member |
 | 21 | Member | Review PR, merge or reject |
-| 22 | COS | Handle failures: reassign, move back to `in_progress` |
+| 22 | COS | Handle failures: reassign, move back to `dev` |
 
 ### Phase 6: Completion
 
 | Step | Actor | Action |
 |------|-------|--------|
-| 23 | COS | Move task to `review` then `completed` |
-| 24 | COS | For big tasks: escalate review to manager before completing |
+| 23 | COS | Move task to `ai_review` then `complete` |
+| 24 | COS | For big tasks: escalate to `human_review` (via manager) before completing |
 | 25 | COS | Report completion to manager |
 | 26 | COS | Assign next task to available member |
 
@@ -79,18 +79,24 @@ resolve AID auth internally; AMAMA supplies no governance/sudo password (R28/R32
 
 ## Task Statuses
 
-| # | Status | Code | Description |
-|---|--------|------|-------------|
-| 1 | Backlog | `backlog` | Entry point, not yet prioritized |
-| 2 | Pending | `pending` | Prioritized, ready to start |
-| 3 | In Progress | `in_progress` | Active work |
-| 4 | Review | `review` | Under review (AI or human) |
-| 5 | Completed | `completed` | Done |
+Task status is the **ratified 17-column kanban vocabulary**, 1:1 with the TRDD `column:`
+field — 14 lifecycle + 3 exception columns. Consumers align TO it, never the reverse
+(ai-maestro R25 / TRDD-YUGDER9D):
+
+```
+backburner → todo → design → dispatch → dev → testing → ai_review → human_review → complete
+  → publish → published   (tools)
+  → deploy → live → live_auditing   (services)
+exception (orthogonal): blocked · failed · superseded
+```
+
+See `skills/amama-github-routing/references/task-system-sync.md` for the full column table
+and the GitHub-Project mapping.
 
 ## Task Routing
 
-- **Small**: `in_progress` -> `review` -> `completed`
-- **Big**: `in_progress` -> `review` (escalate to manager) -> `completed`
+- **Small**: `dev` -> `testing` -> `ai_review` -> `complete`
+- **Big**: `dev` -> `testing` -> `ai_review` -> `human_review` (escalate to manager) -> `complete`
 
 ## Communication
 

--- a/scripts/amama_proposal_approvals.py
+++ b/scripts/amama_proposal_approvals.py
@@ -3,8 +3,9 @@
 AMAMA Proposal Approvals
 
 Batch-review the TRDD proposals in ``design/proposals/`` and act on them
-with the fast user/MANAGER syntax described in
-``~/.claude/rules/trdd-approval-tiers.md`` Part A (Batch approval syntax).
+with the fast user/MANAGER syntax described in the IND base
+``~/.claude/rules/trdd-design-tasks.md`` (folder lifecycle) and the
+ai-maestro overlay ``aimaestro-trdd-approval.md`` Part A (batch approval syntax).
 
 Two subcommands:
 
@@ -437,7 +438,7 @@ def build_plan(manifest: dict, approved: list[int], refused: list[int]) -> dict:
         # yet the complement `known - refuse_set` would still fire and
         # MASS-APPROVE the entire backlog off a phantom subtrahend (a stale or
         # typo'd number like `--refused 99` silently approving everything). The
-        # `refused:` verb's contract (trdd-approval-tiers.md Part A) is
+        # `refused:` verb's contract (aimaestro-trdd-approval.md Part A) is
         # "refuse the named few, approve the rest" — it presumes the named few
         # are real. With zero real targets there is no defensible "rest" to
         # approve, so we reject instead of acting. A MIX of valid+unknown
@@ -682,6 +683,13 @@ def find_in(folder: Path, ident: str) -> Path | None:
     """
     if not folder.is_dir():
         return None
+    # An 8-char base36 trdd-id is WRITTEN uppercase but LOOKED UP case-insensitively
+    # (per the TRDD id spec). Comparing case-sensitively made a lowercase `ident`
+    # report "not found" for a TRDD sitting right there on disk — a confident wrong
+    # answer, not a crash. Normalize both sides. Case-folding CANNOT merge two
+    # distinct ids (a valid id has no lowercase to fold), so the AmbiguousId guard
+    # below is fully preserved.
+    ident_norm = ident.upper()
     short_matches: list[Path] = []
     for path in sorted(folder.glob("*.md")):
         if path.name.lower() == "readme.md":
@@ -693,9 +701,10 @@ def find_in(folder: Path, ident: str) -> Path | None:
         tid = fm.get("trdd-id", "")
         if not tid:
             continue
-        if tid == ident:
+        tid_norm = tid.upper()
+        if tid_norm == ident_norm:
             return path  # exact full-id match — always unambiguous, wins immediately
-        if tid[:8] == ident:
+        if tid_norm[:8] == ident_norm:
             short_matches.append(path)
     if not short_matches:
         return None
@@ -709,7 +718,15 @@ def find_in(folder: Path, ident: str) -> Path | None:
 
 
 def cmd_archive(args: argparse.Namespace) -> int:
-    """Archive once-approved TRDD(s) from design/tasks/ → design/archived/ (terminal-DONE)."""
+    """Archive once-approved TRDD(s) from design/tasks/ → design/archived/ (terminal-DONE).
+
+    AWARENESS (``--state completed``): before archiving a code-bearing TRDD as
+    completed, confirm its ``implementation-commits:`` records the landed SHAs.
+    That backtracking field is how a bug found later is traced to the TRDD that
+    introduced it (IND ``trdd-design-tasks.md``); a "done" TRDD with no commits is
+    either untraceable or was never implemented. A docs/decision-only TRDD
+    legitimately has none. (This is documented expectation, not a hard gate.)
+    """
     root = project_root(args.root)
     state = (getattr(args, "state", None) or "cancelled").lower()
     if state not in ARCHIVE_STATES:

--- a/skills/amama-amcos-coordination/references/ai-maestro-message-templates.md
+++ b/skills/amama-amcos-coordination/references/ai-maestro-message-templates.md
@@ -57,7 +57,7 @@ The message will arrive with the following structure:
 - **Content fields**:
   - `type`: `status_report`
   - `overall_progress`: A percentage string (e.g., "67%")
-  - `active_tasks`: A list of tasks, each with `specialist` (AMOA/AMAA/AMIA), `task` (description), and `status` (pending/in_progress/review/completed)
+  - `active_tasks`: A list of tasks, each with `specialist` (AMOA/AMAA/AMIA), `task` (description), and `status` (one of the ratified 17 kanban columns — e.g. `dev`/`testing`/`ai_review`/`human_review`/`complete`)
   - `blockers`: A list of blockers, each with `description` and `assigned_to`
   - `next_milestone`: Description of the next milestone
   - `health`: One of `green`, `yellow`, or `red`

--- a/skills/amama-approval-workflows/SKILL.md
+++ b/skills/amama-approval-workflows/SKILL.md
@@ -13,9 +13,10 @@ GovernanceRequest API workflows. Two tracks:
 - **Governance** (this skill): Team, COS, agent lifecycle, transfers.
 - **Operational** (`amama-amcos-coordination`): Deploys, merges, tests.
 
-**Tier ladder:** these approvals sit on the canonical required-permissions ladder in
-`~/.claude/rules/trdd-approval-tiers.md` (Tier 0 agent-independent → 1 COS → 2 MANAGER →
-3 USER/MAESTRO; operationalized by the `amama-proposal-approvals` skill). A request only the
+**Tier ladder:** these approvals sit on the canonical required-permissions ladder in the
+ai-maestro overlay `aimaestro-trdd-approval.md` (which expands the IND base
+`~/.claude/rules/trdd-design-tasks.md`): Tier 0 agent-independent → 1 COS → 2 MANAGER →
+3 USER/MAESTRO; operationalized by the `amama-proposal-approvals` skill. A request only the
 user can grant is **Tier 3 = escalate-to-MAESTRO**.
 
 ## Prerequisites

--- a/skills/amama-approval-workflows/references/legacy-approval-types.md
+++ b/skills/amama-approval-workflows/references/legacy-approval-types.md
@@ -13,7 +13,7 @@ GovernanceRequest API. They travel on the AMP messaging system, arriving from
 the team's **CHIEF-OF-STAFF** (R6 v3 — a team member never messages you directly;
 the COS is the sole entry point) and surfaced by you to the user. Publish,
 deploy, and security actions are **hard-floor escalations to the USER** (Tier 3,
-`trdd-approval-tiers.md` / `manager-approval-defaults.md`) regardless of any
+`aimaestro-trdd-approval.md` / `aimaestro-manager-approval-defaults.md`) regardless of any
 autonomous-fallback verdict.
 
 ## Push Approval

--- a/skills/amama-autonomous-fallback/SKILL.md
+++ b/skills/amama-autonomous-fallback/SKILL.md
@@ -14,7 +14,8 @@ Decides what to do with an inbound approval request when the user is `monitoring
 The `escalate-to-user` verdict targets the **currently-active MAESTRO / DELEGATE** (R36/R37) — AMAMA obeys only that user; every other native/foreign user is subordinate. Per-role authority (R28-derived title, never self-asserted): COS gets the full matrix; AUTONOMOUS is one notch stricter (C → defer); MAINTAINER is restricted to the issue-triage subset.
 
 **Tier ladder:** the matrix verdicts map onto the canonical required-permissions ladder in
-`~/.claude/rules/trdd-approval-tiers.md` — `approve-autonomously` stays within MANAGER
+the ai-maestro overlay `aimaestro-trdd-approval.md` (expanding the IND base
+`~/.claude/rules/trdd-design-tasks.md`) — `approve-autonomously` stays within MANAGER
 authority (Tier ≤ 2), while **`escalate-to-user` = Tier 3** (USER/MAESTRO).
 
 ## Prerequisites

--- a/skills/amama-github-routing/references/decision-trees-and-routing.md
+++ b/skills/amama-github-routing/references/decision-trees-and-routing.md
@@ -148,13 +148,13 @@ LINK     LINK     │ Route to │   │ Route to │
 | Operation | Route To | Handoff Content | Task Sync |
 |-----------|----------|-----------------|-----------|
 | Sync board with GitHub | AMIA | Project ID, sync scope | Full reconciliation with task file |
-| Create design card | AMAA | Design UUID, card details, team label | Create task entry as `backlog` |
-| Create module card | AMOA | Module UUID, card details, team label | Create task entry as `backlog` |
+| Create design card | AMAA | Design UUID, card details, team label | Create task entry as `backburner` |
+| Create module card | AMOA | Module UUID, card details, team label | Create task entry as `backburner` |
 | Move card (non-specific) | AMIA | Card ID, target column, team label | Update task status |
 | Move design card | AMAA | Card ID, design context | Update task status |
 | Move module card | AMOA | Card ID, module context | Update task status |
 | Query board status | AMAMA (local) | Project ID | Read from task file for fast response |
-| Archive completed items | AMIA | Project ID, archive criteria | Remove `completed` tasks older than threshold |
+| Archive completed items | AMIA | Project ID, archive criteria | Remove `complete`/`published`/`live` tasks older than threshold |
 
 ### Kanban-to-Task Sync Procedure
 

--- a/skills/amama-github-routing/references/handoff-templates-and-uuid.md
+++ b/skills/amama-github-routing/references/handoff-templates-and-uuid.md
@@ -26,7 +26,7 @@
 - Verification criteria
 
 ### Task Sync Required
-- AI Maestro task status to set: [backlog|pending|in_progress|review|completed]
+- AI Maestro task status to set: [one of the ratified 17 kanban columns — see task-system-sync reference]
 - Task file: ~/.aimaestro/teams/tasks-{teamId}.json
 ```
 
@@ -49,7 +49,7 @@
 - GitHub item updated with design reference
 
 ### Task Sync Required
-- AI Maestro task status to set: [backlog|pending|in_progress|review|completed]
+- AI Maestro task status to set: [one of the ratified 17 kanban columns — see task-system-sync reference]
 - Task file: ~/.aimaestro/teams/tasks-{teamId}.json
 ```
 
@@ -72,7 +72,7 @@
 - Acceptance criteria
 
 ### Task Sync Required
-- AI Maestro task status to set: [backlog|pending|in_progress|review|completed]
+- AI Maestro task status to set: [one of the ratified 17 kanban columns — see task-system-sync reference]
 - Task file: ~/.aimaestro/teams/tasks-{teamId}.json
 ```
 

--- a/skills/amama-github-routing/references/proactive-kanban-monitoring.md
+++ b/skills/amama-github-routing/references/proactive-kanban-monitoring.md
@@ -17,7 +17,7 @@ parent-skill: amama-github-routing
 
 ## Proactive Kanban Monitoring
 
-AMAMA must proactively monitor GitHub Project boards to detect changes that may require action or notification to the orchestrator and the user.
+AMAMA must proactively monitor GitHub Project boards to detect changes that may require action or notification. **Comm-graph v3 (R6 v3):** the MANAGER may NOT message a team-internal agent (ORCHESTRATOR, ARCHITECT, INTEGRATOR, MEMBER) directly — the team's **CHIEF-OF-STAFF is the sole in-team gateway** and relays to the orchestrator/specialists on your behalf. So every in-team notification below is addressed to the team's CHIEF-OF-STAFF; the user (HUMAN) remains directly reachable.
 
 ### Monitoring Schedule
 
@@ -40,10 +40,10 @@ gh project item-list <PROJECT_NUMBER> --owner Emasoft --format json | jq '
 
 | Change Type | Detection Method | Action |
 |-------------|------------------|--------|
-| Status changes | Compare `status` field against previous snapshot | Notify orchestrator of card movement |
-| New assignees | Compare `assignees` array against previous snapshot | Notify relevant specialist |
-| New comments | Check `comments` count increase | Fetch new comments, route to appropriate agent |
-| Card created | New "id" value not in previous snapshot | Route to orchestrator for triage |
+| Status changes | Compare `status` field against previous snapshot | Notify the team's CHIEF-OF-STAFF of card movement (COS relays to the orchestrator in-team) |
+| New assignees | Compare `assignees` array against previous snapshot | Notify the team's CHIEF-OF-STAFF (COS relays to the relevant specialist in-team) |
+| New comments | Check `comments` count increase | Fetch new comments, route to the team's CHIEF-OF-STAFF (COS relays to the appropriate agent) |
+| Card created | New "id" value not in previous snapshot | Route to the team's CHIEF-OF-STAFF for triage (COS relays to the orchestrator) |
 | Card archived | "id" value missing from current snapshot | Update internal tracking state |
 
 ### Monitoring Procedure
@@ -66,8 +66,8 @@ diff <(jq -S '.items' /tmp/kanban-snapshot-previous.json) \
 For each detected change:
 
 1. **Status Change Detected**
-   Send a kanban update notification to the orchestrator using the `agent-messaging` skill:
-   - **Recipient**: `orchestrator-<project>`
+   Send a kanban update notification to the team's CHIEF-OF-STAFF using the `agent-messaging` skill (the COS relays it to the orchestrator in-team — R6 v3 forbids a direct MANAGER→orchestrator edge):
+   - **Recipient**: the team's CHIEF-OF-STAFF (`cos-<team>`)
    - **Subject**: "Kanban Card Status Changed"
    - **Content**: kanban_update type with card_id, card_title, old_status, new_status, changed_at
    - **Type**: `kanban_update`
@@ -76,13 +76,13 @@ For each detected change:
    **Verify**: confirm message delivery via the skill's sent messages feature.
 
 2. **New Assignee Detected**
-   - If assignee is a known specialist agent, notify that agent
+   - If assignee is a known specialist agent, notify the team's CHIEF-OF-STAFF, which relays to that specialist in-team (R6 v3 — MANAGER may not message a specialist directly)
    - If assignee is external, log for user review
 
 3. **New Comment Detected**
    - Fetch comment content
-   - Route to appropriate agent based on card context
-   - If comment mentions user action needed, notify user
+   - Route to the team's CHIEF-OF-STAFF based on card context (COS relays to the appropriate agent in-team)
+   - If comment mentions user action needed, notify the user directly (MANAGER→HUMAN is an allowed edge)
 
 **Step 4: Update Internal State**
 ```bash
@@ -97,7 +97,7 @@ mv /tmp/kanban-snapshot-current.json /tmp/kanban-snapshot-previous.json
 - [ ] Previous snapshot exists for comparison
 - [ ] Current snapshot captured successfully
 - [ ] Changes detected and categorized
-- [ ] Orchestrator notified of relevant changes
+- [ ] Team's CHIEF-OF-STAFF notified of relevant changes (COS relays in-team; no direct MANAGER→orchestrator/specialist edge, R6 v3)
 - [ ] Internal state updated
 - [ ] Sync log updated with timestamp
 

--- a/skills/amama-github-routing/references/routing-examples.md
+++ b/skills/amama-github-routing/references/routing-examples.md
@@ -39,14 +39,14 @@
 - Issue number returned
 
 ### Task Sync Required
-- AI Maestro task status to set: backlog
+- AI Maestro task status to set: backburner
 - Task file: ~/.aimaestro/teams/tasks-backend.json
 
 # Output
 [ROUTED] GitHub issue → AMIA
 Team: team:backend
 Handoff: Sent
-Task Sync: Synced → backlog
+Task Sync: Synced → backburner
 Reference: #52
 ```
 
@@ -59,19 +59,19 @@ Reference: #52
 # AMAMA decision process
 1. Operation type: KANBAN (MOVE CARD)
 2. Check team label on #45: team:backend
-3. Map "In Review" column → AI Maestro status: review
+3. Map "In Review" column → AI Maestro status: ai_review
 4. Route to: AMIA
 
 # Task sync
 Update ~/.aimaestro/teams/tasks-backend.json:
-- Task linked to #45: status "in_progress" → "review"
+- Task linked to #45: status "dev" → "ai_review"
 - Append to statusHistory
 
 # Output
 [ROUTED] GitHub kanban → AMIA
 Team: team:backend
 Handoff: Sent
-Task Sync: Synced → review
+Task Sync: Synced → ai_review
 Reference: #45
 ```
 
@@ -88,13 +88,13 @@ Reference: #45
 4. Route to: AMAA
 
 # Task sync
-Create entry in ~/.aimaestro/teams/tasks-design.json with status: backlog
+Create entry in ~/.aimaestro/teams/tasks-design.json with status: backburner
 
 # Output
 [ROUTED] GitHub kanban → AMAA
 Team: team:design
 Handoff: Sent
-Task Sync: Synced → backlog
+Task Sync: Synced → backburner
 Reference: design-uuid-abc123
 ```
 

--- a/skills/amama-github-routing/references/task-system-sync.md
+++ b/skills/amama-github-routing/references/task-system-sync.md
@@ -11,15 +11,37 @@ All Kanban card movements and issue status changes must be synced with AI Maestr
 
 ## Task Status Model
 
-AI Maestro uses a 5-status pipeline for all tasks:
+AI Maestro's task status is the **ratified 17-column kanban vocabulary**, 1:1 with the
+TRDD `column:` field. It is the single source of truth — every consumer (this task file,
+the GitHub Project board, `amp-kanban-*.sh`, role-plugins) aligns TO it, never the reverse
+(ai-maestro R25 / TRDD-YUGDER9D). The set is **14 lifecycle** columns followed by **3
+exception** columns:
 
-| Status | Description | GitHub Kanban Column | Transitions From | Transitions To |
-|--------|-------------|---------------------|------------------|----------------|
-| `backlog` | Identified but not yet prioritized | Backlog | (entry) | `pending` |
-| `pending` | Prioritized and ready to be picked up | To Do / Ready | `backlog` | `in_progress` |
-| `in_progress` | Actively being worked on | In Progress | `pending` | `review` |
-| `review` | Work complete, awaiting review/approval | In Review | `in_progress` | `completed`, `in_progress` |
-| `completed` | Done and verified | Done | `review` | (terminal) |
+| # | Status | Kind | GitHub Project Status option |
+|---|--------|------|------------------------------|
+| 1 | `backburner` | lifecycle | Backburner |
+| 2 | `todo` | lifecycle | To Do |
+| 3 | `design` | lifecycle | Design |
+| 4 | `dispatch` | lifecycle | Dispatch |
+| 5 | `dev` | lifecycle | Dev |
+| 6 | `testing` | lifecycle | Testing |
+| 7 | `ai_review` | lifecycle | AI Review |
+| 8 | `human_review` | lifecycle | Human Review |
+| 9 | `complete` | lifecycle | Complete |
+| 10 | `publish` | lifecycle | Publish |
+| 11 | `published` | lifecycle | Published |
+| 12 | `deploy` | lifecycle | Deploy |
+| 13 | `live` | lifecycle | Live |
+| 14 | `live_auditing` | lifecycle | Live Auditing |
+| 15 | `blocked` | exception | Blocked |
+| 16 | `failed` | exception | Failed |
+| 17 | `superseded` | exception | Superseded |
+
+Lifecycle order: `backburner → todo → design → dispatch → dev → testing → ai_review →
+human_review → complete`, then `publish → published` (tools) or `deploy → live →
+live_auditing` (services). The exception columns are orthogonal: `blocked` (has an unmet
+`blocked-by:`), `failed` (retryable — stays OPEN), `superseded`. GitHub-Project Status
+options mirror these 17 labels exactly.
 
 ## Task File Format
 
@@ -35,15 +57,15 @@ AI Maestro uses a 5-status pipeline for all tasks:
       "githubIssue": 45,
       "githubRepo": "owner/repo",
       "title": "Implement user auth",
-      "status": "in_progress",
+      "status": "dev",
       "assignedAgent": "amoa-backend-auth",
       "teamLabel": "team:backend",
       "designUuid": "abc-123",
       "moduleUuid": "def-456",
       "statusHistory": [
-        {"status": "backlog", "timestamp": "2025-01-28T10:00:00Z", "actor": "amama-main"},
-        {"status": "pending", "timestamp": "2025-01-29T09:00:00Z", "actor": "amama-main"},
-        {"status": "in_progress", "timestamp": "2025-01-30T14:00:00Z", "actor": "amoa-backend-auth"}
+        {"status": "backburner", "timestamp": "2025-01-28T10:00:00Z", "actor": "amama-main"},
+        {"status": "todo", "timestamp": "2025-01-29T09:00:00Z", "actor": "amama-main"},
+        {"status": "dev", "timestamp": "2025-01-30T14:00:00Z", "actor": "amoa-backend-auth"}
       ],
       "createdAt": "2025-01-28T10:00:00Z",
       "updatedAt": "2025-01-30T14:00:00Z"
@@ -75,20 +97,26 @@ jq --arg taskId "$TASK_ID" --arg newStatus "$NEW_STATUS" --arg actor "$SESSION_N
 | Direction | Trigger | Action |
 |-----------|---------|--------|
 | GitHub to AI Maestro | Kanban card moved | Update `tasks-{teamId}.json` with new status |
-| GitHub to AI Maestro | Issue closed | Set task status to `completed` |
-| GitHub to AI Maestro | Issue reopened | Set task status to `in_progress` |
+| GitHub to AI Maestro | Issue closed | Set task status to `complete` |
+| GitHub to AI Maestro | Issue reopened | Set task status to `dev` |
 | AI Maestro to GitHub | Task status changed via API | Move corresponding Kanban card |
 | AI Maestro to GitHub | New task created | Create GitHub issue with team label |
 
 ## Status Mapping: GitHub Kanban Columns to AI Maestro Statuses
 
-| GitHub Kanban Column | AI Maestro Status |
-|---------------------|-------------------|
-| Backlog | `backlog` |
-| To Do / Ready | `pending` |
-| In Progress | `in_progress` |
-| In Review / Review | `review` |
-| Done / Closed | `completed` |
+The canonical GitHub-Project Status field carries all 17 columns 1:1 (see the Task Status
+Model table above). A board that renders a coarser summary view GROUPS columns for display,
+but every mutation must round-trip back to the full 17-column vocabulary:
+
+| Coarse GitHub board column | AI Maestro Status(es) it groups |
+|----------------------------|---------------------------------|
+| Backlog | `backburner` |
+| To Do / Ready | `todo`, `design`, `dispatch` |
+| In Progress | `dev`, `testing` |
+| In Review | `ai_review`, `human_review` |
+| Done | `complete`, `publish`, `published`, `deploy`, `live`, `live_auditing` |
+| Blocked / Failed | `blocked`, `failed`, `superseded` |
 
 If a GitHub project uses custom column names, AMAMA must maintain a mapping in:
-`~/.aimaestro/teams/kanban-column-map-{teamId}.json`
+`~/.aimaestro/teams/kanban-column-map-{teamId}.json` — but the mapping always resolves to
+one of the ratified 17 columns; never invent a new column value.

--- a/skills/amama-label-taxonomy/SKILL.md
+++ b/skills/amama-label-taxonomy/SKILL.md
@@ -22,15 +22,18 @@ Label taxonomy for AMAMA. Manages priority labels, status labels, and translates
 ## Instructions
 
 1. **Analyze request** -- determine priority (`priority:critical|high|normal|low`) and type (`type:bug|feature|...`)
-2. **Create issue** with labels: `status:backlog`, `priority:*`, `type:*`
+2. **Create issue** with labels: `status:backburner`, `priority:*`, `type:*`
 3. **Monitor status changes** from other agents; translate to user messages
 4. **Update priorities** when user expresses urgency changes
 5. **Set blocked** (as a flag) when user requests pause
 6. **Facilitate review** when AMIA escalates
 7. **Report status** by querying issues with relevant labels
 
-**Sets**: `status:backlog|review`, all `priority:*`.
-**Monitors only**: `status:pending|in_progress|review|completed`, `assign:*`.
+Status labels use the ratified 17-column kanban vocabulary (1:1 with the TRDD `column:`;
+see label-tables reference). AMAMA touches only the entry + human-review + block columns:
+
+**Sets**: `status:backburner` (new task entry), `status:human_review` (escalate for user review), `status:blocked` (flag), all `priority:*`.
+**Monitors** (set by other agents): the lifecycle `status:todo|design|dispatch|dev|testing|ai_review|complete` and the release columns `status:publish|published|deploy|live|live_auditing`, plus `assign:*`.
 **Never sets**: `assign:*`, `review:*`, `effort:*`, `component:*`.
 
 See label-tables reference for full label tables and approval authority.
@@ -43,13 +46,13 @@ See label-tables reference for full label tables and approval authority.
 ```bash
 # Create issue (the --body MUST begin with the G1.1 self-id line)
 gh issue create --title "$TITLE" --body "$BODY" \
-  --label "status:backlog" --label "priority:$PRI" --label "type:$TYPE"
+  --label "status:backburner" --label "priority:$PRI" --label "type:$TYPE"
 # Change priority
 gh issue edit $NUM --remove-label "priority:normal" --add-label "priority:high"
 # Block/unblock
 gh issue edit $NUM --add-label "status:blocked"
 # Status report
-gh issue list --label "status:in-progress" --json number,title,labels
+gh issue list --label "status:dev" --json number,title,labels
 ```
 
 See commands-and-patterns reference for all commands and patterns.
@@ -93,7 +96,7 @@ Copy this checklist and track your progress:
 ```bash
 gh issue create --title "Login page broken" \
   --body "$(printf '%s\n\n%s\n' '_Posted by the Claude developing **ai-maestro-assistant-manager-agent** (the MANAGER), via the shared @owner gh auth._' 'User reported urgent login page issue')" \
-  --label "type:bug" --label "priority:critical" --label "status:backlog"
+  --label "type:bug" --label "priority:critical" --label "status:backburner"
 ```
 
 **Response**: "Created issue #123 (critical). The orchestrator will triage shortly."
@@ -112,5 +115,5 @@ See commands-and-patterns reference for more examples.
 
 ## Resources
 
-- [label-tables](references/label-tables.md): Priority Labels, Kanban Columns (Canonical 5-Status Model), Status Labels AMAMA Updates, Labels AMAMA Monitors, Labels AMAMA Never Sets, AMAMA's Approval Authority
+- [label-tables](references/label-tables.md): Priority Labels, Kanban Columns (ratified 17-column vocabulary), Status Labels AMAMA Updates, Labels AMAMA Monitors, Labels AMAMA Never Sets, AMAMA's Approval Authority
 - [commands-and-patterns](references/commands-and-patterns.md): Label Commands, User Communication Patterns, Full Examples

--- a/skills/amama-label-taxonomy/references/commands-and-patterns.md
+++ b/skills/amama-label-taxonomy/references/commands-and-patterns.md
@@ -17,7 +17,7 @@
 gh issue create \
   --title "$USER_REQUEST_TITLE" \
   --body "$USER_REQUEST_BODY" \
-  --label "status:backlog" \
+  --label "status:backburner" \
   --label "priority:$PRIORITY" \
   --label "type:$TYPE"
 ```
@@ -33,31 +33,31 @@ gh issue edit $ISSUE_NUMBER --remove-label "priority:normal" --add-label "priori
 
 ```bash
 # Mark blocked
-gh issue edit $ISSUE_NUMBER --remove-label "status:in-progress" --add-label "status:blocked"
+gh issue edit $ISSUE_NUMBER --remove-label "status:dev" --add-label "status:blocked"
 ```
 
 ### When Facilitating Human Review
 
 ```bash
-# Present the task to the user for review (escalated from Review)
+# Present the task to the user for review (escalated to human_review)
 gh issue view $ISSUE_NUMBER --json title,body,labels
 # After user approves:
-gh issue edit $ISSUE_NUMBER --remove-label "status:review" --add-label "status:completed"
+gh issue edit $ISSUE_NUMBER --remove-label "status:human_review" --add-label "status:complete"
 # After user requests changes:
-gh issue edit $ISSUE_NUMBER --remove-label "status:review" --add-label "status:in-progress"
+gh issue edit $ISSUE_NUMBER --remove-label "status:human_review" --add-label "status:dev"
 ```
 
 ### When Generating Status Report
 
 ```bash
 # Get all active issues for user
-gh issue list --label "status:in-progress" --json number,title,labels
+gh issue list --label "status:dev" --json number,title,labels
 
 # Get issues in review
-gh issue list --label "status:review" --json number,title,labels
+gh issue list --label "status:human_review" --json number,title,labels
 
 # Get completed issues
-gh issue list --label "status:completed" --state closed --json number,title
+gh issue list --label "status:complete" --state closed --json number,title
 ```
 
 ---
@@ -71,7 +71,7 @@ When user asks "What's happening with my request?":
 ```markdown
 **Issue #42: Add user authentication**
 
-- **Status**: In Progress (`status:in-progress`)
+- **Status**: In Progress (`status:dev`)
 - **Priority**: High (`priority:high`)
 - **Assigned to**: Implementation Agent 1 (`assign:implementer-1`)
 - **Type**: New Feature (`type:feature`)
@@ -88,7 +88,7 @@ The implementation agent is actively working on this task.
 | "Something is broken" | `type:bug`, `priority:high` |
 | "Can you add..." | `type:feature` |
 | "Put this on hold" | `status:blocked` |
-| "Resume this" | Remove `status:blocked`, add `status:pending` |
+| "Resume this" | Remove `status:blocked`, add `status:todo` |
 
 ---
 
@@ -105,7 +105,7 @@ gh issue create \
   --body "$(printf '%s\n\n%s\n' '_Posted by the Claude developing **ai-maestro-assistant-manager-agent** (the MANAGER), via the shared @owner gh auth._' 'User reported urgent login page issue')" \
   --label "type:bug" \
   --label "priority:critical" \
-  --label "status:backlog"
+  --label "status:backburner"
 ```
 
 **User response**: "Created issue #123 with critical priority. The orchestrator will triage this shortly."
@@ -124,7 +124,7 @@ gh issue list --label "component:auth" --json number,title,labels
 **Authentication Issues**:
 
 - **#42**: Add OAuth support
-  - Status: In Progress (`status:in-progress`)
+  - Status: In Progress (`status:dev`)
   - Priority: High (`priority:high`)
   - Assigned to: Implementation Agent 1
 

--- a/skills/amama-label-taxonomy/references/label-tables.md
+++ b/skills/amama-label-taxonomy/references/label-tables.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 - [Priority Labels](#priority-labels-priority)
-- [Kanban Columns (Canonical 5-Status Model)](#kanban-columns-canonical-5-status-model)
+- [Kanban Columns (Ratified 17-Column Vocabulary)](#kanban-columns-ratified-17-column-vocabulary)
 - [Status Labels AMAMA Updates](#status-labels-amama-updates)
 - [Labels AMAMA Monitors](#labels-amama-monitors)
 - [Labels AMAMA Never Sets](#labels-amama-never-sets)
@@ -24,39 +24,57 @@
 - Escalate priority when user expresses urgency
 - De-escalate when user indicates reduced urgency
 
-## Kanban Columns (Canonical 5-Status Model)
+## Kanban Columns (Ratified 17-Column Vocabulary)
 
-| # | Column Code | Display Name | Label | Description |
-|---|-------------|-------------|-------|-------------|
-| 1 | `backlog` | Backlog | `status:backlog` | Entry point for new tasks |
-| 2 | `pending` | Pending | `status:pending` | Ready to start |
-| 3 | `in_progress` | In Progress | `status:in-progress` | Active work |
-| 4 | `review` | Review | `status:review` | Integrator agent reviews ALL tasks; significant tasks escalated to manager |
-| 5 | `completed` | Completed | `status:completed` | Completed |
+The GitHub `status:*` label taxonomy is 1:1 with the ratified 17-column kanban vocabulary
+(the TRDD `column:` field). Consumers align TO it, never the reverse (ai-maestro R25 /
+TRDD-YUGDER9D). The label value IS the column name verbatim:
+
+| # | Column Code | Label | Kind | Description |
+|---|-------------|-------|------|-------------|
+| 1 | `backburner` | `status:backburner` | lifecycle | Entry point for new tasks, not yet prioritized |
+| 2 | `todo` | `status:todo` | lifecycle | Prioritized, ready to be picked up |
+| 3 | `design` | `status:design` | lifecycle | Architecture / requirements analysis |
+| 4 | `dispatch` | `status:dispatch` | lifecycle | Assignee being matched |
+| 5 | `dev` | `status:dev` | lifecycle | Active work |
+| 6 | `testing` | `status:testing` | lifecycle | Tests / audits running |
+| 7 | `ai_review` | `status:ai_review` | lifecycle | AI / integrator review |
+| 8 | `human_review` | `status:human_review` | lifecycle | Escalated for user review (via AMAMA) |
+| 9 | `complete` | `status:complete` | lifecycle | Done and verified |
+| 10 | `publish` | `status:publish` | lifecycle | Entering the tool-release pipeline |
+| 11 | `published` | `status:published` | lifecycle | Artifact live to users |
+| 12 | `deploy` | `status:deploy` | lifecycle | Entering the service-deploy pipeline |
+| 13 | `live` | `status:live` | lifecycle | Service live to users |
+| 14 | `live_auditing` | `status:live_auditing` | lifecycle | Post-release soak |
+| 15 | `blocked` | `status:blocked` | exception | Has an unmet `blocked-by:` (a flag) |
+| 16 | `failed` | `status:failed` | exception | Retryable — stays OPEN |
+| 17 | `superseded` | `status:superseded` | exception | Replaced by another task |
 
 **Task Routing Rules:**
-- **Small tasks**: In Progress -> Review -> Completed
-- **Big tasks**: In Progress -> Review (escalate to manager) -> Completed
-- **Review** is requested via AMAMA (Assistant Manager asks user to test/review)
-- Not all tasks go through Review -- only significant changes requiring human judgment
+- **Small tasks**: `dev` -> `testing` -> `ai_review` -> `complete`
+- **Big tasks**: `dev` -> `testing` -> `ai_review` -> `human_review` (escalate to manager) -> `complete`
+- **`human_review`** is requested via AMAMA (Assistant Manager asks user to test/review)
+- Not all tasks reach `human_review` -- only significant changes requiring human judgment
 
 ## Status Labels AMAMA Updates
 
 | Label | When AMAMA Sets It |
 |-------|------------------|
-| `status:backlog` | When creating new issue from user request |
-| `status:review` | When AMIA escalates a significant task for user review (via AMAMA) |
+| `status:backburner` | When creating new issue from user request |
+| `status:human_review` | When AMIA escalates a significant task for user review (via AMAMA) |
+| `status:blocked` | When the user requests a pause (a flag) |
 
 ## Labels AMAMA Monitors
 
 ### Status Labels (`status:*`)
 
-AMAMA reports status to user:
-- `status:backlog` - "Your request has been logged"
-- `status:pending` - "Your request is queued and ready to start"
-- `status:in-progress` - "Work has started on your request"
-- `status:review` - "The AI integrator is reviewing the work"
-- `status:completed` - "Your request is complete"
+AMAMA reports status to user (see the full 17-column table above for every value):
+- `status:backburner` - "Your request has been logged"
+- `status:todo` - "Your request is queued and ready to start"
+- `status:dev` - "Work has started on your request"
+- `status:ai_review` - "The AI integrator is reviewing the work"
+- `status:human_review` - "Your input is needed to review the work"
+- `status:complete` - "Your request is complete"
 
 ### Assignment Labels (`assign:*`)
 

--- a/skills/amama-role-routing/references/governance-and-specializations.md
+++ b/skills/amama-role-routing/references/governance-and-specializations.md
@@ -52,8 +52,13 @@ This SUPERSEDES any older text stating team/COS creation needs USER approval, a 
 | Orchestrator | `amoa-` | ai-maestro-orchestrator-agent | `ORCHESTRATOR` |
 | Integrator | `amia-` | ai-maestro-integrator-agent | `INTEGRATOR` |
 | Member (programmer) | — | ai-maestro-programmer-agent | `MEMBER` |
+| Maintainer | `amma-` | ai-maestro-maintainer-agent | `MAINTAINER` |
+| Autonomous | `amaua-` | ai-maestro-autonomous-agent | `AUTONOMOUS` |
 
-Extra project-specific agents are MEMBER-titled on the member-agent role plugin (R30).
+Every persisted agent MUST carry exactly one role plugin (R9.13). The two governance-layer
+titles have a mandatory mapping: MAINTAINER → `ai-maestro-maintainer-agent`, AUTONOMOUS →
+`ai-maestro-autonomous-agent`. Extra project-specific agents are MEMBER-titled on the
+member-agent role plugin (R30).
 
 ## Communication Hierarchy
 

--- a/skills/amama-status-reporting/SKILL.md
+++ b/skills/amama-status-reporting/SKILL.md
@@ -37,7 +37,7 @@ Generate status reports by querying AI Maestro APIs for live agent, team, and ta
 5. Compile into report format and save to `reports/status-reporting/`
 6. Present formatted report to user
 
-Task Kanban statuses flow: `backlog -> pending -> in_progress -> review -> completed`. See task-system reference for details.
+Task Kanban statuses use the ratified 17-column vocabulary: `backburner → todo → design → dispatch → dev → testing → ai_review → human_review → complete` (+ `publish/published` or `deploy/live/live_auditing`), with exception columns `blocked · failed · superseded`. See task-system reference for details.
 
 For API query examples, see api-endpoints reference.
 
@@ -73,8 +73,8 @@ For detailed report section formats, see report-formats reference.
 | amoa-orchestrator | active | 1h 42m |
 ### Task Kanban
 | Status | Count |
-| in_progress | 2 |
-| completed | 4 |
+| dev | 2 |
+| complete | 4 |
 **Blockers**: AMIA unresponsive -- escalating
 ```
 

--- a/skills/amama-status-reporting/references/report-formats.md
+++ b/skills/amama-status-reporting/references/report-formats.md
@@ -13,7 +13,7 @@
 | Quick Status | On demand | Current state summary | `aimaestro-agent.sh list` |
 | Progress Report | Daily/Weekly | Work completed, in progress, blocked | team tasks (`/api/teams/{id}/tasks` — CLI verb pending ai-maestro#36) + GitHub |
 | Handoff Summary | On transition | What was handed to whom | `aimaestro-agent.sh list` + handoff files |
-| Blocker Report | As needed | What's blocking progress | team tasks (`/api/teams/{id}/tasks` — CLI verb pending ai-maestro#36) (pending/in_progress) |
+| Blocker Report | As needed | What's blocking progress | team tasks (`/api/teams/{id}/tasks` — CLI verb pending ai-maestro#36) (`blocked` + `dev`/`testing`) |
 
 **Note**: Blockers are reported to the user IMMEDIATELY when received, not held for the next scheduled status report.
 
@@ -31,18 +31,18 @@
 ### Quick Status Format
 - Agent sessions: online/offline counts (from `aimaestro-agent.sh list`)
 - Session liveness: active/inactive (from `aimaestro-agent.sh list` — proxies agent health; no dedicated agent-health command exists)
-- Current active tasks (from team tasks where status = `in_progress`; `/api/teams/{id}/tasks` — CLI verb pending ai-maestro#36)
+- Current active tasks (from team tasks where status = `dev`; `/api/teams/{id}/tasks` — CLI verb pending ai-maestro#36)
 - Next milestone
 - Blockers (if any)
 
 ### Progress Report Format
 - Period covered
 - **Kanban Summary** (from team tasks; `/api/teams/{id}/tasks` — CLI verb pending ai-maestro#36):
-  - Tasks in `backlog`: count and titles
-  - Tasks `pending`: count and titles
-  - Tasks `in_progress`: count, titles, assignees
-  - Tasks in `review`: count and titles
-  - Tasks `completed` (this period): count, titles, completion dates
+  - Tasks in `backburner`/`todo`: count and titles
+  - Tasks in `dev`/`testing`: count, titles, assignees
+  - Tasks in `ai_review`/`human_review`: count and titles
+  - Tasks `complete` (this period): count, titles, completion dates
+  - Exception columns `blocked`/`failed`: count and titles
 - **Agent Status** (from `aimaestro-agent.sh list`):
   - Active sessions with uptime
   - Stale / inactive sessions (if any — these proxy "unresponsive" agents)
@@ -68,11 +68,11 @@ Session status proxies agent health: `active` with recent heartbeat = alive, `in
 ### Task Kanban
 | Status | Count | Tasks |
 |--------|-------|-------|
-| backlog | 3 | Session mgmt, Logging, Metrics |
-| pending | 1 | Auth middleware |
-| in_progress | 2 | Login endpoint, User model |
-| review | 1 | DB schema |
-| completed | 4 | Setup, Config, Router, Models |
+| backburner | 3 | Session mgmt, Logging, Metrics |
+| todo | 1 | Auth middleware |
+| dev | 2 | Login endpoint, User model |
+| ai_review | 1 | DB schema |
+| complete | 4 | Setup, Config, Router, Models |
 
 **Blockers**: AMIA integrator agent unresponsive — escalating to AMCOS
 ```
@@ -95,10 +95,10 @@ Session status proxies agent health: `active` with recent heartbeat = alive, `in
 - Logout endpoint (AMOA, started 2025-01-30)
 - Session management design (AMAA, started 2025-01-29)
 
-**Pending:**
+**Todo:**
 - Password reset endpoint (blocked by email service config)
 
-**Backlog:**
+**Backburner:**
 - OAuth2 integration
 - Rate limiting
 

--- a/skills/amama-status-reporting/references/task-system.md
+++ b/skills/amama-status-reporting/references/task-system.md
@@ -12,16 +12,31 @@ Tasks are stored in: `~/.aimaestro/teams/tasks-{teamId}.json`
 
 ## Task Statuses (Kanban)
 
-Tasks flow through exactly 5 statuses:
+Tasks use the **ratified 17-column kanban vocabulary**, 1:1 with the TRDD `column:` field.
+It is the single source of truth — consumers align TO it, never the reverse (ai-maestro
+R25 / TRDD-YUGDER9D). 14 lifecycle columns flow:
 
 ```
-backlog -> pending -> in_progress -> review -> completed
+backburner -> todo -> design -> dispatch -> dev -> testing -> ai_review -> human_review -> complete
+  -> publish -> published        (tools)
+  -> deploy -> live -> live_auditing   (services)
 ```
+
+plus 3 orthogonal exception columns: `blocked`, `failed`, `superseded`.
 
 | Status | Meaning |
 |--------|---------|
-| `backlog` | Acknowledged but not yet scheduled |
-| `pending` | Scheduled, waiting to start |
-| `in_progress` | Actively being worked on by an agent |
-| `review` | Work done, awaiting review/validation |
-| `completed` | Finished and verified |
+| `backburner` | Acknowledged but not yet prioritized |
+| `todo` | Prioritized, waiting to start |
+| `design` | Architecture / requirements analysis |
+| `dispatch` | Assignee being matched |
+| `dev` | Actively being worked on by an agent |
+| `testing` | Tests / audits running |
+| `ai_review` | AI / integrator review |
+| `human_review` | Awaiting user review/validation |
+| `complete` | Finished and verified |
+| `publish` / `published` | Tool-release pipeline |
+| `deploy` / `live` / `live_auditing` | Service-release pipeline |
+| `blocked` | Has an unmet `blocked-by:` (a flag) |
+| `failed` | Retryable — stays OPEN |
+| `superseded` | Replaced by another task |

--- a/tests/test_proposal_approvals.py
+++ b/tests/test_proposal_approvals.py
@@ -422,5 +422,48 @@ def test_ambiguous_short_id_does_not_misroute_archive():
         assert exact is not None and "first" in exact.name
 
 
+def _write_task(tdir: Path, tid: str, slug: str) -> Path:
+    """Write one synthetic APPROVED task with a given trdd-id; return its path."""
+    tdir.mkdir(parents=True, exist_ok=True)
+    path = tdir / f"TRDD-idcase-{slug}.md"
+    path.write_text(
+        f"---\ntrdd-id: {tid}\n"
+        f"title: Idcase {slug}\ncolumn: dev\n"
+        f"created: 2026-06-01T10:00:00+0200\n"
+        f"updated: 2026-06-01T10:00:00+0200\napproval-tier: 2\n"
+        f"---\n\n# Idcase {slug}\n\n## Approval log\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_find_in_short_and_full_id_are_case_insensitive():
+    """A trdd-id is written uppercase but looked up case-insensitively (UPPER/lower/MiXeD all resolve)."""
+    with temp_repo() as (root, _ids):
+        tdir = ppa.tasks_dir(root)
+        want = _write_task(tdir, "K3QX9P2W", "canonical8")  # canonical 8-char base36 id
+        for ident in ("K3QX9P2W", "k3qx9p2w", "K3qx9P2w"):
+            got = ppa.find_in(tdir, ident)
+            assert got == want, f"lookup {ident!r} should resolve the uppercase-stored id"
+
+
+def test_case_folding_does_not_defeat_ambiguous_guard():
+    """Case-insensitive lookup must still raise AmbiguousId on two distinct ids sharing a short prefix."""
+    with temp_repo() as (root, _ids):
+        tdir = ppa.tasks_dir(root)
+        # Two DISTINCT ids sharing the same first 8 chars (case-insensitively).
+        _write_task(tdir, "K3QX9P2WAAAA", "collide_a")
+        _write_task(tdir, "K3QX9P2WBBBB", "collide_b")
+        raised = False
+        try:
+            ppa.find_in(tdir, "k3qx9p2w")  # lowercase short id — collides on both
+        except ppa.AmbiguousId:
+            raised = True
+        assert raised, "case-folding must not merge two distinct ids — AmbiguousId still fires"
+        # Each full id (any case) still resolves unambiguously to its own file.
+        assert (ppa.find_in(tdir, "k3qx9p2waaaa") or Path()).name.endswith("collide_a.md")
+        assert (ppa.find_in(tdir, "K3QX9P2WBBBB") or Path()).name.endswith("collide_b.md")
+
+
 if __name__ == "__main__":
     sys.exit(run_standalone(globals()))


### PR DESCRIPTION
_Posted by the Claude developing **ai-maestro** (via the shared @Emasoft gh auth)._

Closes #24. Syncs the plugin's STALE 3-pillars governance content to the already-ratified current state. Correct-by-construction: every replacement is grounded in the canonical ai-maestro sources (`types/task.ts` + R25 for the 17 columns; `lib/communication-graph.ts` for comm-graph v3; the IND base `trdd-design-tasks.md`/`prrd-design-rules.md`/`universal-kanban.md` + the DEP overlays `aimaestro-*.md`). No governance is invented.

## What was synced (audit items 1–11)

| # | Item | Done |
|---|------|------|
| 1–5 | 5-status kanban (`backlog/pending/in_progress/review/completed`) → ratified **17-column** vocabulary | ✅ `task-system-sync.md`, `handoff-templates-and-uuid.md`, `routing-examples.md`, `amama-label-taxonomy` (SKILL + `label-tables.md` + `commands-and-patterns.md`), `docs/FULL_PROJECT_WORKFLOW.md`, `docs/AGENT_OPERATIONS.md` |
| 6 | Comm-graph v3 in `proactive-kanban-monitoring.md` | ✅ every in-team recipient → the team's **CHIEF-OF-STAFF** (COS relays in-team); user stays directly reachable (MANAGER→HUMAN is an allowed edge). Zero forbidden-edge instructions remain |
| 7 | 9 dangling rule refs → IND + DEP names | ✅ `trdd-approval-tiers.md`/`manager-approval-defaults.md` → `trdd-design-tasks.md` (IND) + `aimaestro-trdd-approval.md` / `aimaestro-manager-approval-defaults.md` (DEP); persona gained DEP-overlay awareness (`aimaestro-prrd-governance.md`, `aimaestro-kanban-multiagent.md`) |
| 8 | Case-insensitive short/full trdd-id lookup | ✅ `find_in()` normalizes both sides; `AmbiguousId` guard preserved; **2 new tests** pin it |
| 9 | `implementation-commits:` awareness | ✅ as documented expectation (persona + archive-command docstring) — see follow-up below |
| 10 | AUTONOMOUS/MAINTAINER mandatory role-plugin rows (R9.13) | ✅ `governance-and-specializations.md` prefix table + main-agent governance-title rows |
| 11 | Cosmetic | ✅ `R6 v2` → `v3`; `ama-proposal-approvals` → `amama-proposal-approvals` |

The canonical 17-column list is **referenced** (not re-inlined) wherever a source allowed, so it can't re-drift; GitHub `status:*` labels now carry the column name verbatim.

## Scope note — 3 extra files synced for coherence

Beyond the audit's explicitly-named files, the identical stale 5-status vocabulary also lived in **`amama-status-reporting`** (SKILL + `task-system.md` + `report-formats.md`), **`decision-trees-and-routing.md`**, and **`amama-amcos-coordination/…/ai-maestro-message-templates.md`**. Leaving them would have made the plugin self-contradict (one ref teaching 17 columns, another teaching "exactly 5"), so they are synced too. This is the same mechanical vocabulary swap, not a design change.

## Deferred as follow-ups (not guessed here)

1. **Item 9 as a hard gate.** This PR adds `implementation-commits:` *awareness*. Turning it into a blocking gate (refuse to archive a code-bearing TRDD as `completed` when `implementation-commits:` is empty) is a genuine behavioral design addition with edge cases — detecting "code-bearing" vs docs/decision-only, and the `failed→cancelled` interplay. The canonical IND rule describes the field as accumulating ("append as code lands"), not as an archive gate, so the enforcing variant is left for a separate, deliberate change.
2. **Internal dev-memory refs (out of audit scope).** `.claude/project/memory/*.md` still reference the raw `~/.claude/rules/trdd-approval-tiers.md` / `manager-approval-defaults.md`. Those are the plugin's internal wiki-memory (not shipped agent-facing content) and were deliberately excluded from the audit's 9-ref count; they'll dangle once the IND rules ship under the new names. Flagging for a memory-hygiene pass.

## Validation (non-publishing)

- `uv run pytest tests/` → **111 passed** (incl. the 2 new `find_in` case-insensitivity tests and the existing README-sync test).
- `ruff check` on the changed script + test → clean.
- Mega-Linter runs on this PR's CI as usual (markdownlint has `MD013` disabled, so the long governance tables are fine).
- `publish.py` was **not** run; no version bump (docs/skills content, no PR-convention bump required).

_Agent: ai-maestro-assistant-manager-agent-sync_
