### PR TITLE
fix(persona): sequence project-bootstrap NPT + delegate repo creation to MAINTAINER

### DIFF
--- a/agents/ai-maestro-assistant-manager-agent-main-agent.md
+++ b/agents/ai-maestro-assistant-manager-agent-main-agent.md
@@ -462,7 +462,8 @@ All frozen CLIs resolve your AID auth automatically. NEVER use the user's govern
 1. Create the team via `aimaestro-teams.sh create --name N [opts]` — no governance password needed for MANAGER
 2. The server auto-creates a COS agent (starts hibernated)
 3. Wake the COS via `aimaestro-agent.sh wake <cosId>`
-4. Brief the COS with the project requirements via AMP message (`amp-send`)
+4. Brief the COS with the project requirements via AMP message (`amp-send`) — **only after the requirements/spec are LANDED on `main`** (or whatever base the dev's TRDD will actually branch from). If they are staged in a PR, **merge that PR first**; never route a build request whose NPT is satisfied only by an unmerged PR (TRDD-BYCN5PB7) — the dev's own STATE-block NPT gate will correctly refuse to build otherwise, soft-deadlocking the fleet.
+   - **New GitHub repo needed for this project?** Do not run `gh repo create` yourself. Author a mandate TRDD assigning repo-create-from-template + branch-rules + CI + clone to the **MAINTAINER** (TRDD-5F3490TA) — you orchestrate the bootstrap, MAINTAINER executes it.
 5. Create the 4 remaining base members yourself — ARCHITECT, ORCHESTRATOR, INTEGRATOR, MEMBER — via `aimaestro-agent.sh create ... --governanceTitle <title>`, no user approval (R29). The team stays FROZEN until the COS + all 5 base members exist (R31).
 6. Grant the COS its mandate so it can add any extra project-specific MEMBER agents (R30); wake the base members
 

--- a/skills/amama-amcos-coordination/references/workflow-checklists.md
+++ b/skills/amama-amcos-coordination/references/workflow-checklists.md
@@ -18,6 +18,7 @@ When a new project team is needed (you create it yourself — R29, no user appro
 
 - [ ] **Parse the request** for project name, purpose, and requirements
 - [ ] **Clarify ambiguities** if team scope or agent assignments are not specified
+- [ ] **New GitHub repo needed?** Do not create it yourself — author a mandate TRDD assigning repo-create-from-template + branch-rules + CI + clone to the **MAINTAINER** (TRDD-5F3490TA); you orchestrate, MAINTAINER executes the repo bootstrap
 - [ ] **Verify team name available** (redirect `aimaestro-teams.sh list` to a scratch file, then `grep` it for the name — a match ⇒ name already taken; don't read the raw listing into context)
 - [ ] **Create the team yourself** via `aimaestro-teams.sh create --name N --type closed [...]` (R29) — the server auto-creates the COS
 - [ ] **Verify team created** (redirect `aimaestro-teams.sh list` to a scratch file, then `grep` it for the team name/id), and `chiefOfStaff` set via `aimaestro-teams.sh show <team-id>`
@@ -99,6 +100,7 @@ When user gives a work request:
   - Design/plan → ARCHITECT (via AMCOS)
   - Build/implement → ORCHESTRATOR (via AMCOS)
   - Review/test/release → INTEGRATOR (via AMCOS)
+- [ ] **Requirements landed on a mergeable base?** For a build/implement request, confirm the spec/requirements are on `main` (or another merged base) — not sitting only in an open PR. If staged in a PR, merge it FIRST; never dispatch work whose NPT is satisfied only by an unmerged PR (TRDD-BYCN5PB7)
 - [ ] **Identify target AMCOS** (which project?)
 - [ ] **Verify AMCOS exists and is alive**
   - Check active sessions log


### PR DESCRIPTION
_Posted by the Claude developing the **ai-maestro / SCEN-031 harness** (via the shared @Emasoft gh auth)._

## Summary

Fixes #32 — two MANAGER project-bootstrap persona defects found by the SCEN-031 fleet-ship scenario test.

1. **NPT-ordering (TRDD-BYCN5PB7).** The "create a team for a project" workflow now says explicitly: land requirements/spec on `main` (or another merged base) **before** briefing the COS / routing a build request. If staged in a PR, merge it first. Never dispatch a dev whose NPT is satisfied only by an unmerged PR — that's exactly what soft-deadlocked the fleet in the SCEN-031 run (the dev correctly refused to build past its own STATE-block NPT gate, but nobody had merged the requirements PR).
2. **Repo-delegation (TRDD-5F3490TA).** The same workflow now says: a new GitHub repo is bootstrapped by the **MAINTAINER** via a mandate TRDD (repo-create-from-template + branch-rules + CI + clone) — the MANAGER orchestrates this, it does not run `gh repo create` itself.

Both are additive clarifications to the existing "When the user asks to create a team for a project" procedure — no restructuring, no renumbering of existing steps.

## Files changed

- `agents/ai-maestro-assistant-manager-agent-main-agent.md` — Team Lifecycle Management section, step 4 (briefing) gets the NPT-ordering rule + a new sub-bullet on MAINTAINER repo delegation.
- `skills/amama-amcos-coordination/references/workflow-checklists.md` — mirrors the same two rules into "Checklist: Creating New Team" (repo delegation) and "Checklist: Routing User Request to AMCOS" (NPT-ordering before a build dispatch), so the operationalized checklist stays in sync with the persona.

## Test plan

- [x] Read the full persona file before editing (931 lines) and confirmed neither behavior was previously specified anywhere — both were MANAGER improvisation, not persona-directed.
- [x] Grepped `tests/` for any assertion on the edited prose — none found.
- [x] Verified `.markdownlint.json` has MD029 (ordered-list numbering) disabled, so the nested `-` sub-bullet under numbered step 4 is not a lint concern.
- [ ] Not run: `publish.py` / version bump / release — left to the repo owner per cross-repo policy (this PR is a plain feature branch, not a release).

## Risk

Low — text-only persona/skill clarification, no code, no schema change, no renumbering of existing steps or checklist items.
